### PR TITLE
Per-packet idle timer reset (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Reset idle timer on every relayed data packet, not just on connection release — long-running streaming connections now properly keep services alive
+
 ## [0.2.0] - 2026-03-23
 
 ### Added

--- a/elixir/apps/drawbridge_core/lib/drawbridge_core/service_manager.ex
+++ b/elixir/apps/drawbridge_core/lib/drawbridge_core/service_manager.ex
@@ -49,6 +49,14 @@ defmodule DrawbridgeCore.ServiceManager do
     end
   end
 
+  @doc "Acknowledge a data packet relay, resetting the idle timer without touching connection counts."
+  def ack(service_name) do
+    case lookup(service_name) do
+      {:ok, pid} -> GenServer.cast(pid, :ack)
+      :error -> :ok
+    end
+  end
+
   @doc "Get current state info for a service."
   def get_state(service_name) do
     case lookup(service_name) do
@@ -170,6 +178,12 @@ defmodule DrawbridgeCore.ServiceManager do
 
     {:reply, :ok, %{s | state: :stopped, ip: nil, started_at: nil, active_connections: 0}}
   end
+
+  def handle_cast(:ack, %{state: :running} = s) do
+    {:noreply, reset_idle_timer(s)}
+  end
+
+  def handle_cast(:ack, s), do: {:noreply, s}
 
   @impl true
   def handle_cast(:release_connection, s) do

--- a/elixir/apps/drawbridge_core/test/drawbridge_core/service_manager_test.exs
+++ b/elixir/apps/drawbridge_core/test/drawbridge_core/service_manager_test.exs
@@ -127,6 +127,36 @@ defmodule DrawbridgeCore.ServiceManagerTest do
     assert {:error, :service_not_found} = ServiceManager.request_connection("no-such-service-xyz")
   end
 
+  test "ack resets idle timer while running", %{svc: svc} do
+    pid = start_manager(svc)
+    send(pid, {:container_ready, svc.name, "127.0.0.1", svc.ports})
+    Process.sleep(20)
+
+    # Request + release to start idle timer
+    {:ok, _} = ServiceManager.request_connection(svc.name, 1_000)
+    ServiceManager.release_connection(svc.name)
+    Process.sleep(10)
+
+    # Grab the timer ref before ack
+    %{idle_timer: timer_before} = :sys.get_state(pid)
+    assert timer_before != nil
+
+    # ack should reset the timer (new ref)
+    ServiceManager.ack(svc.name)
+    Process.sleep(10)
+    %{idle_timer: timer_after} = :sys.get_state(pid)
+    assert timer_after != nil
+    assert timer_after != timer_before
+  end
+
+  test "ack is ignored when not running", %{svc: svc} do
+    _pid = start_manager(svc)
+    # Service is :not_pulled, ack should be a no-op (no crash)
+    assert :ok = ServiceManager.ack(svc.name)
+    info = ServiceManager.get_state(svc.name)
+    assert info.state == :not_pulled
+  end
+
   test "running state returns immediately on request_connection", %{svc: svc} do
     pid = start_manager(svc)
     send(pid, {:container_ready, svc.name, "192.168.1.1", svc.ports})

--- a/elixir/apps/drawbridge_proxy/lib/drawbridge_proxy/port_handler.ex
+++ b/elixir/apps/drawbridge_proxy/lib/drawbridge_proxy/port_handler.ex
@@ -123,6 +123,7 @@ defmodule DrawbridgeProxy.PortHandler do
         %{msg_ok: msg_ok, socket: socket, backend_socket: backend, transport: transport} = data
       ) do
     data = maybe_detect_protocol(chunk, data)
+    DrawbridgeCore.ServiceManager.ack(data.service_name)
 
     case :gen_tcp.send(backend, chunk) do
       :ok ->
@@ -140,6 +141,8 @@ defmodule DrawbridgeProxy.PortHandler do
         {:tcp, socket, chunk},
         %{backend_socket: socket, socket: client, transport: transport} = data
       ) do
+    DrawbridgeCore.ServiceManager.ack(data.service_name)
+
     case transport.send(client, chunk) do
       :ok ->
         :inet.setopts(socket, active: :once)

--- a/elixir/apps/drawbridge_proxy/lib/drawbridge_proxy/sni_handler.ex
+++ b/elixir/apps/drawbridge_proxy/lib/drawbridge_proxy/sni_handler.ex
@@ -139,6 +139,7 @@ defmodule DrawbridgeProxy.SniHandler do
         %{msg_ok: msg_ok, socket: socket, backend_socket: backend, transport: transport} = data
       ) do
     data = maybe_detect_protocol(chunk, data)
+    DrawbridgeCore.ServiceManager.ack(data.service_name)
 
     case :gen_tcp.send(backend, chunk) do
       :ok ->
@@ -156,6 +157,8 @@ defmodule DrawbridgeProxy.SniHandler do
         {:tcp, socket, chunk},
         %{backend_socket: socket, socket: client, transport: transport} = data
       ) do
+    DrawbridgeCore.ServiceManager.ack(data.service_name)
+
     case transport.send(client, chunk) do
       :ok ->
         :inet.setopts(socket, active: :once)


### PR DESCRIPTION
## Summary

- Adds `ServiceManager.ack/1` — a fire-and-forget cast that resets the idle timer without touching connection counts
- Calls `ack` on every relayed data packet in both `SniHandler` and `PortHandler` (both client→backend and backend→client directions)
- Previously, the idle timer was only reset when connections were released — long-running streaming connections could idle-timeout mid-stream

## Test plan

- [x] Unit test: `ack resets idle timer while running` — verifies timer ref changes after ack
- [x] Unit test: `ack is ignored when not running` — verifies no crash on non-running service
- [x] All 137 existing tests pass

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)