### PR TITLE
Evaluate swift-erlang-actor-system fork (#23)

### DIFF
--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -2,14 +2,25 @@
 import PackageDescription
 
 // NOTE: swift-erlang-actor-system is the intended transport for Erlang distribution
-// protocol integration. It's currently pre-alpha with SSH-only submodules that break
-// CI builds. The dependency is excluded for now — all actor code is stubbed with
+// protocol integration. The upstream (otp-interop) uses SSH-only git submodules that
+// break CI builds. The dependency is excluded for now — all actor code is stubbed with
 // TODO markers showing where ErlangActorSystem integration points go.
 //
-// To enable locally:
-//   1. Add: .package(url: "https://github.com/otp-interop/swift-erlang-actor-system.git", branch: "main")
+// EVALUATED (2026-03-23, #23): mbearne-fresha's fork fixes the SSH submodule issue
+// by switching .gitmodules to HTTPS URLs. It also adds critical stability fixes:
+//   - Non-blocking ei_accept_tmo() accept loop (no thread pool starvation)
+//   - Proper socket cleanup on node disconnect (fixes CLOSE_WAIT leak)
+//   - Graceful shutdown() method (breaks retain cycles)
+//   - Error handling in handleMessage (no more try! crashes)
+// dev_proxy uses this fork in production with native Erlang distribution.
+// See issue #23 for full evaluation and migration plan.
+//
+// To enable (when ready to migrate from JSON IPC to Erlang distribution):
+//   1. Add: .package(url: "https://github.com/mbearne-fresha/swift-erlang-actor-system", branch: "main")
 //   2. Add: .product(name: "ErlangActorSystem", package: "swift-erlang-actor-system") to target deps
 //   3. Uncomment `import ErlangActorSystem` in ContainerManager.swift and DrawbridgeAgent.swift
+//   4. Replace CommandServer JSON IPC with ErlangActorSystem + distributed actor registration
+//   5. CI needs: macos-26 runner, `brew install erlang`, EPMD started before build
 
 let package = Package(
     name: "DrawbridgeAgent",


### PR DESCRIPTION
## Summary

- Evaluated `mbearne-fresha/swift-erlang-actor-system` fork used by dev_proxy
- Fork fixes the SSH submodule CI blocker (switches to HTTPS URLs) and adds critical stability fixes (non-blocking accept, socket cleanup, proper error handling, shutdown method)
- Updated `swift/Package.swift` comments with evaluation findings and migration instructions
- Posted detailed analysis as comment on #23

## Test plan

- [x] Research only — no functional changes
- [x] Package.swift still builds (comments only)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)